### PR TITLE
Add an ability to template `info.plist` using the workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,6 @@ RUN apk add --no-cache \
 
 COPY entrypoint.sh /entrypoint.sh
 COPY extract_name.py /extract_name.py
+COPY template_info_plist.py /template_info_plist.py
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,40 @@ This action needs a file named `info.plist` with the metadata of your workflow i
 
 * `workflow_dir`: Directory containing the sources of the workflow (defaults to `workflow`)
 * `exclude_patterns`: List of excluded files/directories
+* `template_files`: List of comma separated paths to files that would be used to template your `info.plist` file.
+> #### Why it can be helpful?
+> let's imagine that you have a `Script filter` where you wrote your python code,
+> but you would like to develop the code using an IDE like pycharm, so using the option you can form your workflow from several files.
+> 
+> #### Usage:
+>  To be able to add content of the files into you should put a template string into `info.plist` with the following structure:
+   `TEMPLATE_THIS_[0-9]+`.  
+   For example, if you want to put content of two files into `info.plist`, you should set 
+   `template_files: "example1.py,example2.py"`, and put the template strings to the `info.plist` 
+> ```xml
+> ...
+> <string>TEMPLATE_THIS_1
+> </string>
+> ...
+> <string>TEMPLATE_THIS_2
+> </string>
+> ...
+> ```
+> each file will correspond to each template accordingly: `example1.py` will replace `TEMPLATE_THIS_1` and  `example2.py` will replace `TEMPLATE_THIS_2`  
+> also you can put one file several times, just put the same template string to several places:
+> ```xml
+> ...
+> <string>TEMPLATE_THIS_1
+> </string>
+> ...
+> <string>TEMPLATE_THIS_2
+> </string>
+> ...
+> <string>TEMPLATE_THIS_1
+> </string>
+> ...
+> ```
+> 
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build Alfred Workflow
-    	id: alfred_builder
+      id: alfred_builder
       uses: mperezi/build-alfred-workflow@v1
       with:
         workflow_dir: src

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'List of excluded files/directories'
     required: false
     default: ''
+  template_files:
+    description: 'List of comma separated paths to files that would be used to template your `info.plist` file. See README.md for an additional info'
+    required: false
+    default: ''
 outputs:
   workflow_file:
     description: 'The name of the created .alfredworkflow file'

--- a/action.yml
+++ b/action.yml
@@ -26,3 +26,4 @@ runs:
   args:
     - ${{ inputs.workflow_dir }}
     - ${{ inputs.exclude_patterns }}
+    - ${{ inputs.template_files }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,10 @@ set -o noglob
 
 WORKFLOW_DIR="$1"
 EXCLUDE_PATTERNS="$2"
+if [[ "$3" ]]; then
+    export TEMPLATE_FILES="$3"
+fi
+
 
 abort() {
 	echo $1 >&2
@@ -58,6 +62,10 @@ set_output() {
 
 check_info_plist
 check_workflow_dir
+
+if [[ "$3" ]]; then
+  /template_info_plist.py info.plist
+fi
 
 OUTPUT_FILE="${PWD}/$(/extract_name.py info.plist)"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ set -o noglob
 
 WORKFLOW_DIR="$1"
 EXCLUDE_PATTERNS="$2"
-if [[ "$3" ]]; then
+if [ -n "${3-}" ]; then
     export TEMPLATE_FILES="$3"
 fi
 
@@ -63,7 +63,7 @@ set_output() {
 check_info_plist
 check_workflow_dir
 
-if [[ "$3" ]]; then
+if [ -n "${3-}" ]; then
   /template_info_plist.py info.plist
 fi
 

--- a/template_info_plist.py
+++ b/template_info_plist.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+
+import sys
+import os
+import re
+
+template_str_regex = re.compile("TEMPLATE_THIS_[0-9]+")
+template_file_number = re.compile(r"\d+")
+
+
+def get_info_plist_content(info_plist):
+    file = open(info_plist, 'r')
+    info_plist_lines = []
+    for line in file.readlines():
+        info_plist_lines.append(line)
+    file.close()
+    return info_plist_lines
+
+
+def get_template_matches(info_plist_lines_list, template_files_list):
+    matches = {}
+    info_plist_lines = []
+    for line in info_plist_lines_list:
+        info_plist_lines.append(line)
+        match = template_str_regex.findall(line)
+        if match:
+            for m in match:
+                file_number = int(template_file_number.findall(m)[0]) - 1
+                if matches.get(m):
+                    matches[m][template_files_list[file_number]] += 1
+                else:
+                    matches[m] = {template_files_list[file_number]: 1}
+    return matches
+
+
+def replace_templates_with_files_content(info_plist_lines_list, template_files_list):
+    temp_info_plist = []
+    for line in info_plist_lines_list:
+        match = template_str_regex.findall(line)
+        new_line = line
+        for m in match:
+            file_numbers = template_file_number.findall(m) if m else None
+            if match and file_numbers:
+                for file_number in file_numbers:
+                    file_number = int(file_number) - 1
+                    tf = open(template_files_list[file_number], 'r')
+                    new_line = new_line.replace(m, ''.join(tf.readlines()))
+        temp_info_plist.append(new_line)
+    return temp_info_plist
+
+
+def write_updated_info_plist(info_plist, info_plist_lines_list):
+    info_plist_file = open(info_plist, 'w')
+    for line in info_plist_lines_list:
+        info_plist_file.write(line)
+    info_plist_file.close()
+
+
+def print_what_will_be_replaced(info_plist_matches):
+    for k, v in info_plist_matches.items():
+        print("'%s' will be replaced with '%s' file '%s' times" % (k, v.items(), v.values()))
+
+
+def main():
+    if len(sys.argv) < 2:
+        print('Please provide a info.plist')
+        sys.exit(1)
+
+    info_plist = sys.argv[1]
+
+    if not os.path.exists(info_plist):
+        print('info.plist not found')
+        sys.exit(2)
+
+    template_files = os.environ.get("TEMPLATE_FILES")
+    if template_files:
+        temp_files_list = template_files.split(',')
+
+        info_plist_lines = get_info_plist_content(info_plist)
+        info_plist_matches = get_template_matches(info_plist_lines, temp_files_list)
+
+        if len(temp_files_list) != len(info_plist_matches.keys()):
+            print(
+                """template files and template strings in info.plist are not matching 
+                (probably you are trying to template more files than info.plist contains templating strings or vise versa)"""
+            )
+            sys.exit(2)
+        print_what_will_be_replaced(info_plist_matches)
+        updated_info_plist = replace_templates_with_files_content(info_plist_lines, temp_files_list)
+        write_updated_info_plist(info_plist, updated_info_plist)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Hey pal!

Today I found your workflow, and it seems to me very useful.
but for simple workflows I'm using a simple `Script filter` with the script content in the `info.plist` and it is now so simple
to develop (use an IDE) and espesially present the script logic at github, so I thoud - it would be great if the workflow will get a script content form a separate file and put the content to the `info.plist` file (just replacing a stub) instead of me using my recent update of the script!

So, I forked your workflow and added the ability to it!

For the the explanation how it should work, I updated `README.md` file, and tested the workflow on my simple workflow: https://github.com/com30n/alfred-urbandictionary/actions/runs/3807944407/jobs/6478134696

Everything works perfectly, and I thought to share my changes with you and with other users that also use your workflow.